### PR TITLE
get call to session/current

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -134,6 +134,34 @@ end
 
 
 ###
+# GET /sessions/current
+#
+# Returns 204 if current session exists
+#         400 if session header is missing or session header is invalid
+###
+get '/sessions/current/?' do
+  content_type 'application/vnd.api+json'
+
+  ###
+  # Validate session
+  ###
+
+  session_uri = session_id_header(request)
+  error('Session header is missing') if session_uri.nil?
+
+
+  ###
+  # Get account
+  ###
+
+  result = select_account_by_session(session_uri)
+  error('Invalid session') if result.empty?
+
+  status 204
+end
+
+
+###
 # Helpers
 ###
 


### PR DESCRIPTION
call checks whether the current session exists so authenticators can use
a restore method to restore existing (client-side) sessions.
