### PR TITLE
Feature/mock login verenigingen

### DIFF
--- a/.woodpecker/feature.yml
+++ b/.woodpecker/feature.yml
@@ -1,0 +1,10 @@
+steps:
+  build-feature:
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: ${CI_REPO}
+      tags: "feature-${CI_COMMIT_BRANCH##feature/}"
+    secrets: [ docker_username, docker_password ]
+when:
+  branch: feature/*
+  event: push

--- a/.woodpecker/latest.yml
+++ b/.woodpecker/latest.yml
@@ -1,0 +1,10 @@
+steps:
+  build-latest:
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: ${CI_REPO}
+      tags: latest
+    secrets: [ docker_username, docker_password ]
+when:
+  branch: master
+  event: push

--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -1,0 +1,10 @@
+steps:
+  build-and-release:
+    image: woodpeckerci/plugin-docker-buildx
+    secrets: [ docker_username, docker_password ]
+    settings:
+      repo: ${CI_REPO}
+      tags: ${CI_COMMIT_TAG##v} # strips v from the tag
+when:
+  event: tag
+  tag: v*

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,4 @@ FROM semtech/mu-ruby-template:2.6.0-ruby2.3
 MAINTAINER Erika Pauwels <erika.pauwels@gmail.com>
 
 ENV MU_APPLICATION_SALT ''
+ENV MU_APPLICATION_GRAPH http://mu.semte.ch/graphs/public

--- a/auth_extensions/sudo.rb
+++ b/auth_extensions/sudo.rb
@@ -1,0 +1,17 @@
+module AuthExtensions
+  module Sudo
+    def sparql_client
+      log.info('Create sudo SPARQL client')
+      if @sparql_client.nil?
+        options = {
+          headers: { 'mu-sudo-auth': 'true' }
+        }
+        if ENV['MU_SPARQL_TIMEOUT']
+          options[:read_timeout] = ENV['MU_SPARQL_TIMEOUT'].to_i
+        end
+        @sparql_client = SPARQL::Client.new(ENV['MU_SPARQL_ENDPOINT'], options)
+      end
+      @sparql_client
+    end
+  end
+end

--- a/auth_extensions/sudo.rb
+++ b/auth_extensions/sudo.rb
@@ -4,7 +4,7 @@ module AuthExtensions
       log.info('Create sudo SPARQL client')
       if @sparql_client.nil?
         options = {
-          headers: { 'mu-sudo-auth': 'true' }
+          headers: { 'mu-auth-sudo': 'true' }
         }
         if ENV['MU_SPARQL_TIMEOUT']
           options[:read_timeout] = ENV['MU_SPARQL_TIMEOUT'].to_i

--- a/login_service/sparql_queries.rb
+++ b/login_service/sparql_queries.rb
@@ -1,26 +1,25 @@
 module LoginService
   module SparqlQueries
     def remove_old_sessions(session)
-      query =  " WITH <#{settings.graph}> "
-      query += " DELETE {"
-      query += "   <#{session}> <#{MU_SESSION.account}> ?account ;"
-      query += "                <#{MU_CORE.uuid}> ?id ; "
-      query += "                <#{RDF::Vocab::DC.modified}> ?modified; "
-      query += "                <#{MU_EXT.sessionGroup}> ?group ."
-      query += " }"
-      query += " WHERE {"
-      query += "   <#{session}> <#{MU_SESSION.account}> ?account ;"
-      query += "                <#{MU_CORE.uuid}> ?id ; "
-      query += "                <#{RDF::Vocab::DC.modified}> ?modified; "
-      query += "                <#{MU_EXT.sessionGroup}> ?group ."
+      query += " DELETE WHERE {"
+      query += "   GRAPH <http://mu.semte.ch/graphs/sessions> {"
+      query += "     <#{session}> <#{MU_SESSION.account}> ?account ;"
+      query += "                  <#{MU_CORE.uuid}> ?id ; "
+      query += "                  <#{RDF::Vocab::DC.modified}> ?modified ; "
+      query += "                  <#{MU_EXT.sessionRole}> ?role ;"
+      query += "                  <#{MU_EXT.sessionGroup}> ?group ."
+      query += "   }"
       query += " }"
       update(query)
     end
 
-    def insert_new_session_for_account(account, session_uri, session_id, group_uri, roles)
+    def insert_new_session_for_account(account, session_uri, session_id, group_uri, group_id, roles)
+      now = DateTime.now
+
       query =  " INSERT DATA {"
-      query += "   GRAPH <#{settings.graph}> {"
+      query += "   GRAPH <http://mu.semte.ch/graphs/sessions> {"
       query += "     <#{session_uri}> <#{MU_SESSION.account}> <#{account}> ;"
+      query += "                      <#{RDF::Vocab::DC.modified}> #{now.sparql_escape} ;"
       query += "                      <#{MU_EXT.sessionGroup}> <#{group_uri}> ;"
       query += "                      <#{MU_CORE.uuid}> #{session_id.sparql_escape} ."
       roles.each do |role|
@@ -31,62 +30,88 @@ module LoginService
       update(query)
     end
 
-    def select_group(group_id)
-      query =  " SELECT ?group FROM <#{settings.graph}> WHERE {"
-      query += "  ?group a <#{BESLUIT.Bestuurseenheid}> ;"
-      query += "              <#{MU_CORE.uuid}> \"#{group_id}\" ."
-      query += " }"
-      query(query)
-    end
-
     def select_account_by_session(session)
-      query =  " SELECT ?group_uuid ?account_uuid ?account FROM <#{settings.graph}> WHERE {"
-      query += "   <#{session}> <#{MU_SESSION.account}> ?account ;"
-      query += "                <#{MU_EXT.sessionGroup}> ?group ."
-      query += "   ?group <#{MU_CORE.uuid}> ?group_uuid ."
-      query += "   ?account <#{MU_CORE.uuid}> ?account_uuid ."
-      query += "   ?account a <#{RDF::Vocab::FOAF.OnlineAccount}> ."
+      query =  " SELECT ?group_uuid ?account_uuid ?account WHERE {"
+      query += "   GRAPH <http://mu.semte.ch/graphs/sessions> {"      
+      query += "     <#{session}> <#{MU_SESSION.account}> ?account ;"
+      query += "                  <#{MU_EXT.sessionGroup}> ?group ."
+      query += "   }"
+      query += "   GRAPH <http://mu.semte.ch/graphs/public> {"
+      query += "     ?group a <#{BESLUIT.Bestuurseenheid}> ;"      
+      query += "            <#{MU_CORE.uuid}> ?group_uuid ."
+      query += "   }"
+      query += "   GRAPH ?g {"
+      query += "     ?account a <#{RDF::Vocab::FOAF.OnlineAccount}> ;"
+      query += "              <#{MU_CORE.uuid}> ?account_uuid ."
+      query += "   }"
+      query += "   FILTER(?g = IRI(CONCAT(\"http://mu.semte.ch/graphs/org/\", ?group_uuid)))"
       query += " }"
       query(query)
     end
 
     def select_current_session(account)
-      query =  " SELECT ?uri FROM <#{settings.graph}> WHERE {"
-      query += "   ?uri <#{MU_SESSION.account}> <#{account}> ;"
-      query += "        <#{MU_CORE.uuid}> ?id ; "
-      query += "        <#{MU_EXT.sessionGroup}> ?group ."
+      query =  " SELECT ?uri WHERE {"
+      query += "   GRAPH <http://mu.semte.ch/graphs/sessions> {"      
+      query += "     ?uri <#{MU_SESSION.account}> <#{account}> ;"
+      query += "        <#{MU_CORE.uuid}> ?id . "
+      query += "   }"
       query += " }"
       query(query)
     end
 
     def delete_current_session(account)
-      query =  " WITH <#{settings.graph}> "
-      query += " DELETE {"
-      query += "   ?session <#{MU_SESSION.account}> <#{account}> ;"
-      query += "            <#{MU_CORE.uuid}> ?id ; "
-      query += "            <#{MU_EXT.sessionGroup}> ?group ."
-      query += " }"
-      query += " WHERE {"
-      query += "   ?session <#{MU_SESSION.account}> <#{account}> ;"
-      query += "            <#{MU_CORE.uuid}> ?id ; "
-      query += "            <#{MU_EXT.sessionGroup}> ?group ."
+      query += " DELETE WHERE {"
+      query += "   GRAPH <http://mu.semte.ch/graphs/sessions> {"
+      query += "     ?session <#{MU_SESSION.account}> <#{account}> ;"
+      query += "              <#{MU_CORE.uuid}> ?id ; "
+      query += "              <#{RDF::Vocab::DC.modified}> ?modified ; "
+      query += "              <#{MU_EXT.sessionRole}> ?role ;"
+      query += "              <#{MU_EXT.sessionGroup}> ?group ."
+      query += "   }"
       query += " }"
       update(query)
     end
 
     def select_account(id)
-      query =  " SELECT ?uri FROM <#{settings.graph}> WHERE {"
-      query += "   ?uri <#{MU_CORE.uuid}> \"#{id}\" ."
-      query += "   ?uri a <#{RDF::Vocab::FOAF.OnlineAccount}> ."
+      query =  " SELECT ?uri WHERE {"
+      query += "   GRAPH <http://mu.semte.ch/graphs/public> {"      
+      query += "     ?group a <#{BESLUIT.Bestuurseenheid}> ;"      
+      query += "            <#{MU_CORE.uuid}> ?group_uuid ."
+      query += "   }"
+      query += "   GRAPH ?g {"
+      query += "     ?uri a <#{RDF::Vocab::FOAF.OnlineAccount}> ;"
+      query += "          <#{MU_CORE.uuid}> \"#{id}\" ;"
+      query += "          <#{RDF::Vocab::FOAF.member}> ?group ."
+      query += "   }"
+      query += "   FILTER(?g = IRI(CONCAT(\"http://mu.semte.ch/graphs/org/\", ?group_uuid)))"
       query += " }"
       query(query)
     end
 
+    def select_group(group_id)
+      query =  " SELECT ?group WHERE {"
+      query += "   GRAPH <http://mu.semte.ch/graphs/public> {"
+      query += "      ?group a <#{BESLUIT.Bestuurseenheid}> ;"
+      query += "               <#{MU_CORE.uuid}> \"#{group_id}\" ."
+      query += "   }"
+      query += " }"
+      query(query)
+    end
+
+
     def select_roles(account_id)
-      query =  " SELECT ?role FROM <#{settings.graph}> WHERE {"
-      query += "   ?uri <#{MU_CORE.uuid}> \"#{account_id}\" ."
-      query += "   ?uri a <#{RDF::Vocab::FOAF.OnlineAccount}> ."
-      query += "   ?uri <#{MU_EXT.sessionRole}> ?role."
+      query =  " SELECT ?role WHERE {"
+      query += "   GRAPH <http://mu.semte.ch/graphs/public> {"      
+      query += "     ?group a <#{BESLUIT.Bestuurseenheid}> ;"      
+      query += "            <#{MU_CORE.uuid}> ?group_uuid ."
+      query += "   }"
+      query += "   GRAPH ?g {"
+      query += "     ?uri a <#{RDF::Vocab::FOAF.OnlineAccount}> ;"
+      query += "            <#{MU_CORE.uuid}> \"#{id}\" ;"
+      query += "            <#{MU_EXT.sessionRole}> ?role ;"
+      query += "            <#{RDF::Vocab::FOAF.member}> ?group ."
+      query += "   }"
+      query += "   FILTER(?g = IRI(CONCAT(\"http://mu.semte.ch/graphs/org/\", ?group_uuid)))"
       query += " }"
       query(query)
     end

--- a/login_service/sparql_queries.rb
+++ b/login_service/sparql_queries.rb
@@ -1,55 +1,56 @@
 module LoginService
   module SparqlQueries
-
-    def select_salted_password_and_salt_by_nickname(nickname)
-      query =  " SELECT ?uuid ?uri ?password ?salt FROM <#{settings.graph}> WHERE {"
-      query += "   ?uri a <#{RDF::Vocab::FOAF.OnlineAccount}> ; "
-      query += "        <#{RDF::Vocab::FOAF.accountName}> #{nickname.downcase.sparql_escape} ; "
-      query += "        <#{MU_ACCOUNT.status}> <#{MU_ACCOUNT['status/active']}> ; "
-      query += "        <#{MU_ACCOUNT.password}> ?password ; "
-      query += "        <#{MU_ACCOUNT.salt}> ?salt ; "
-      query += "        <#{MU_CORE.uuid}> ?uuid"
-      query += " }"
-      query(query)
-    end
-
     def remove_old_sessions(session)
       query =  " WITH <#{settings.graph}> "
       query += " DELETE {"
       query += "   <#{session}> <#{MU_SESSION.account}> ?account ;"
-      query += "                <#{MU_CORE.uuid}> ?id . "
+      query += "                <#{MU_CORE.uuid}> ?id ; "
+      query += "                <#{RDF::Vocab::DC.modified}> ?modified; "
+      query += "                <#{MU_SESSION.group}> ?group ."
       query += " }"
       query += " WHERE {"
       query += "   <#{session}> <#{MU_SESSION.account}> ?account ;"
-      query += "                <#{MU_CORE.uuid}> ?id . "
+      query += "                <#{MU_CORE.uuid}> ?id ; "
+      query += "                <#{RDF::Vocab::DC.modified}> ?modified; "
+      query += "                <#{MU_SESSION.group}> ?group ."
       query += " }"
       update(query)
     end
 
-    def insert_new_session_for_account(account, session_uri, session_id)
+    def insert_new_session_for_account(account, session_uri, session_id, group_uri)
       query =  " INSERT DATA {"
       query += "   GRAPH <#{settings.graph}> {"
       query += "     <#{session_uri}> <#{MU_SESSION.account}> <#{account}> ;"
+      query += "                      <#{MU_SESSION.group}> <#{group_uri}> ;"
       query += "                      <#{MU_CORE.uuid}> #{session_id.sparql_escape} ."
       query += "   }"
       query += " }"
       update(query)
     end
-    
+
+    def select_group(group_id)
+      query =  " SELECT ?group FROM <#{settings.graph}> WHERE {"
+      query += "  ?group a <#{BESLUIT.Bestuurseenheid}> ;"
+      query += "              <#{MU_CORE.uuid}> \"#{group_id}\" ."
+      query += " }"
+      query(query)
+    end
+
     def select_account_by_session(session)
-      query =  " SELECT ?uuid ?account FROM <#{settings.graph}> WHERE {"
-      query += "   <#{session}> <#{MU_SESSION.account}> ?account ."
+      query =  " SELECT ?uuid ?account ?group FROM <#{settings.graph}> WHERE {"
+      query += "   <#{session}> <#{MU_SESSION.account}> ?account ;"
+      query += "                <#{MU_SESSION.group}> ?group ."
       query += "   ?account <#{MU_CORE.uuid}> ?uuid ."
-      query += "   <#{session}> <#{MU_SESSION.account}> ?account ."
       query += "   ?account a <#{RDF::Vocab::FOAF.OnlineAccount}> ."
       query += " }"
       query(query)
     end
-    
+
     def select_current_session(account)
       query =  " SELECT ?uri FROM <#{settings.graph}> WHERE {"
       query += "   ?uri <#{MU_SESSION.account}> <#{account}> ;"
-      query += "        <#{MU_CORE.uuid}> ?id . "
+      query += "        <#{MU_CORE.uuid}> ?id ; "
+      query += "        <#{MU_SESSION.group}> ?group ."
       query += " }"
       query(query)
     end
@@ -58,14 +59,23 @@ module LoginService
       query =  " WITH <#{settings.graph}> "
       query += " DELETE {"
       query += "   ?session <#{MU_SESSION.account}> <#{account}> ;"
-      query += "            <#{MU_CORE.uuid}> ?id . "
+      query += "            <#{MU_CORE.uuid}> ?id ; "
+      query += "            <#{MU_SESSION.group}> ?group ."
       query += " }"
       query += " WHERE {"
       query += "   ?session <#{MU_SESSION.account}> <#{account}> ;"
-      query += "            <#{MU_CORE.uuid}> ?id . "
+      query += "            <#{MU_CORE.uuid}> ?id ; "
+      query += "            <#{MU_SESSION.group}> ?group ."
       query += " }"
       update(query)
     end
 
+    def select_account(id)
+      query =  " SELECT ?uri FROM <#{settings.graph}> WHERE {"
+      query += "   ?uri <#{MU_CORE.uuid}> \"#{id}\" ."
+      query += "   ?uri a <#{RDF::Vocab::FOAF.OnlineAccount}> ."
+      query += " }"
+      query(query)
+    end
   end
 end

--- a/login_service/sparql_queries.rb
+++ b/login_service/sparql_queries.rb
@@ -17,12 +17,15 @@ module LoginService
       update(query)
     end
 
-    def insert_new_session_for_account(account, session_uri, session_id, group_uri)
+    def insert_new_session_for_account(account, session_uri, session_id, group_uri, roles)
       query =  " INSERT DATA {"
       query += "   GRAPH <#{settings.graph}> {"
       query += "     <#{session_uri}> <#{MU_SESSION.account}> <#{account}> ;"
       query += "                      <#{MU_EXT.sessionGroup}> <#{group_uri}> ;"
       query += "                      <#{MU_CORE.uuid}> #{session_id.sparql_escape} ."
+      roles.each do |role|
+        query += "   <#{session_uri}> <#{MU_EXT.sessionRole}> #{role.sparql_escape} ."
+      end
       query += "   }"
       query += " }"
       update(query)
@@ -75,6 +78,15 @@ module LoginService
       query =  " SELECT ?uri FROM <#{settings.graph}> WHERE {"
       query += "   ?uri <#{MU_CORE.uuid}> \"#{id}\" ."
       query += "   ?uri a <#{RDF::Vocab::FOAF.OnlineAccount}> ."
+      query += " }"
+      query(query)
+    end
+
+    def select_roles(account_id)
+      query =  " SELECT ?role FROM <#{settings.graph}> WHERE {"
+      query += "   ?uri <#{MU_CORE.uuid}> \"#{account_id}\" ."
+      query += "   ?uri a <#{RDF::Vocab::FOAF.OnlineAccount}> ."
+      query += "   ?uri <#{MU_EXT.sessionRole}> ?role."
       query += " }"
       query(query)
     end

--- a/login_service/sparql_queries.rb
+++ b/login_service/sparql_queries.rb
@@ -1,7 +1,7 @@
 module LoginService
   module SparqlQueries
     def remove_old_sessions(session)
-      query += " DELETE WHERE {"
+      query = " DELETE WHERE {"
       query += "   GRAPH <http://mu.semte.ch/graphs/sessions> {"
       query += "     <#{session}> <#{MU_SESSION.account}> ?account ;"
       query += "                  <#{MU_CORE.uuid}> ?id ; "
@@ -80,10 +80,12 @@ module LoginService
       query += "   }"
       query += "   GRAPH ?g {"
       query += "     ?uri a <#{RDF::Vocab::FOAF.OnlineAccount}> ;"
-      query += "          <#{MU_CORE.uuid}> \"#{id}\" ;"
-      query += "          <#{RDF::Vocab::FOAF.member}> ?group ."
+      query += "          <#{MU_CORE.uuid}> \"#{id}\" ."
+      query += "     ?person a <#{RDF::Vocab::FOAF.Person}> ;"
+      query += "             <#{RDF::Vocab::FOAF.account}> ?uri ;"
+      query += "             <#{RDF::Vocab::FOAF.member}> ?group ."
       query += "   }"
-      query += "   FILTER(?g = IRI(CONCAT(\"http://mu.semte.ch/graphs/org/\", ?group_uuid)))"
+      query += "   BIND(IRI(CONCAT(\"http://mu.semte.ch/graphs/org/\", ?group_uuid)) as ?g)"
       query += " }"
       query(query)
     end
@@ -107,11 +109,13 @@ module LoginService
       query += "   }"
       query += "   GRAPH ?g {"
       query += "     ?uri a <#{RDF::Vocab::FOAF.OnlineAccount}> ;"
-      query += "            <#{MU_CORE.uuid}> \"#{id}\" ;"
-      query += "            <#{MU_EXT.sessionRole}> ?role ;"
-      query += "            <#{RDF::Vocab::FOAF.member}> ?group ."
+      query += "            <#{MU_CORE.uuid}> \"#{account_id}\" ;"
+      query += "            <#{MU_EXT.sessionRole}> ?role ."
+      query += "     ?person a <#{RDF::Vocab::FOAF.Person}> ;"
+      query += "             <#{RDF::Vocab::FOAF.account}> ?uri ;"
+      query += "             <#{RDF::Vocab::FOAF.member}> ?group ."
       query += "   }"
-      query += "   FILTER(?g = IRI(CONCAT(\"http://mu.semte.ch/graphs/org/\", ?group_uuid)))"
+      query += "   BIND(IRI(CONCAT(\"http://mu.semte.ch/graphs/org/\", ?group_uuid)) as ?g)"
       query += " }"
       query(query)
     end

--- a/login_service/sparql_queries.rb
+++ b/login_service/sparql_queries.rb
@@ -61,7 +61,7 @@ module LoginService
     end
 
     def delete_current_session(account)
-      query += " DELETE WHERE {"
+      query = " DELETE WHERE {"
       query += "   GRAPH <http://mu.semte.ch/graphs/sessions> {"
       query += "     ?session <#{MU_SESSION.account}> <#{account}> ;"
       query += "              <#{MU_CORE.uuid}> ?id ; "

--- a/login_service/sparql_queries.rb
+++ b/login_service/sparql_queries.rb
@@ -1,5 +1,7 @@
+require_relative '/usr/src/app/sinatra_template/utils.rb'
 module LoginService
   module SparqlQueries
+    include SinatraTemplate::Utils
     def remove_old_sessions(session)
       query = " DELETE WHERE {"
       query += "   GRAPH <http://mu.semte.ch/graphs/sessions> {"
@@ -33,12 +35,12 @@ module LoginService
 
     def select_account_by_session(session)
       query =  " SELECT ?group_uuid ?account_uuid ?account WHERE {"
-      query += "   GRAPH <http://mu.semte.ch/graphs/sessions> {"      
+      query += "   GRAPH <http://mu.semte.ch/graphs/sessions> {"
       query += "     <#{session}> <#{MU_SESSION.account}> ?account ;"
       query += "                  <#{MU_EXT.sessionGroup}> ?group ."
       query += "   }"
-      query += "   GRAPH <http://mu.semte.ch/graphs/public> {"
-      query += "     ?group a <#{BESLUIT.Bestuurseenheid}> ;"      
+      query += "   GRAPH <#{graph}> {"
+      query += "     ?group a <#{BESLUIT.Bestuurseenheid}> ;"
       query += "            <#{MU_CORE.uuid}> ?group_uuid ."
       query += "   }"
       query += "   GRAPH ?g {"
@@ -52,7 +54,7 @@ module LoginService
 
     def select_current_session(account)
       query =  " SELECT ?uri WHERE {"
-      query += "   GRAPH <http://mu.semte.ch/graphs/sessions> {"      
+      query += "   GRAPH <http://mu.semte.ch/graphs/sessions> {"
       query += "     ?uri <#{MU_SESSION.account}> <#{account}> ;"
       query += "        <#{MU_CORE.uuid}> ?id . "
       query += "   }"
@@ -75,8 +77,8 @@ module LoginService
 
     def select_account(id)
       query =  " SELECT ?uri WHERE {"
-      query += "   GRAPH <http://mu.semte.ch/graphs/public> {"      
-      query += "     ?group a <#{BESLUIT.Bestuurseenheid}> ;"      
+      query += "   GRAPH <#{graph}> {"
+      query += "     ?group a <#{BESLUIT.Bestuurseenheid}> ;"
       query += "            <#{MU_CORE.uuid}> ?group_uuid ."
       query += "   }"
       query += "   GRAPH ?g {"
@@ -93,7 +95,7 @@ module LoginService
 
     def select_group(group_id)
       query =  " SELECT ?group WHERE {"
-      query += "   GRAPH <http://mu.semte.ch/graphs/public> {"
+      query += "   GRAPH <#{graph}> {"
       query += "      ?group a <#{BESLUIT.Bestuurseenheid}> ;"
       query += "               <#{MU_CORE.uuid}> \"#{group_id}\" ."
       query += "   }"
@@ -104,8 +106,8 @@ module LoginService
 
     def select_roles(account_id)
       query =  " SELECT ?role WHERE {"
-      query += "   GRAPH <http://mu.semte.ch/graphs/public> {"      
-      query += "     ?group a <#{BESLUIT.Bestuurseenheid}> ;"      
+      query += "   GRAPH <#{graph}> {"
+      query += "     ?group a <#{BESLUIT.Bestuurseenheid}> ;"
       query += "            <#{MU_CORE.uuid}> ?group_uuid ."
       query += "   }"
       query += "   GRAPH ?g {"

--- a/login_service/sparql_queries.rb
+++ b/login_service/sparql_queries.rb
@@ -32,9 +32,11 @@ module LoginService
     end
 
     def select_account_by_session(session)
-      query =  " SELECT ?group_uuid ?account_uuid ?account WHERE {"
+      query =  " SELECT ?session_uuid ?group_uuid ?account_uuid ?account (GROUP_CONCAT(?role; SEPARATOR = ',') as ?roles) WHERE {"
       query += "   GRAPH <http://mu.semte.ch/graphs/sessions> {"      
-      query += "     <#{session}> <#{MU_SESSION.account}> ?account ;"
+      query += "     <#{session}> <#{MU_CORE.uuid}> ?session_uuid;"
+      query += "                  <#{MU_SESSION.account}> ?account ;"
+      query += "                  <#{MU_EXT.sessionRole}> ?role ;"
       query += "                  <#{MU_EXT.sessionGroup}> ?group ."
       query += "   }"
       query += "   GRAPH <http://mu.semte.ch/graphs/public> {"
@@ -46,7 +48,7 @@ module LoginService
       query += "              <#{MU_CORE.uuid}> ?account_uuid ."
       query += "   }"
       query += "   FILTER(?g = IRI(CONCAT(\"http://mu.semte.ch/graphs/organizations/\", ?group_uuid)))"
-      query += " }"
+      query += " } GROUP BY ?session_uuid ?group_uuid ?account_uuid ?account"
       query(query)
     end
 

--- a/login_service/sparql_queries.rb
+++ b/login_service/sparql_queries.rb
@@ -6,13 +6,13 @@ module LoginService
       query += "   <#{session}> <#{MU_SESSION.account}> ?account ;"
       query += "                <#{MU_CORE.uuid}> ?id ; "
       query += "                <#{RDF::Vocab::DC.modified}> ?modified; "
-      query += "                <#{MU_SESSION.group}> ?group ."
+      query += "                <#{MU_EXT.sessionGroup}> ?group ."
       query += " }"
       query += " WHERE {"
       query += "   <#{session}> <#{MU_SESSION.account}> ?account ;"
       query += "                <#{MU_CORE.uuid}> ?id ; "
       query += "                <#{RDF::Vocab::DC.modified}> ?modified; "
-      query += "                <#{MU_SESSION.group}> ?group ."
+      query += "                <#{MU_EXT.sessionGroup}> ?group ."
       query += " }"
       update(query)
     end
@@ -21,7 +21,7 @@ module LoginService
       query =  " INSERT DATA {"
       query += "   GRAPH <#{settings.graph}> {"
       query += "     <#{session_uri}> <#{MU_SESSION.account}> <#{account}> ;"
-      query += "                      <#{MU_SESSION.group}> <#{group_uri}> ;"
+      query += "                      <#{MU_EXT.sessionGroup}> <#{group_uri}> ;"
       query += "                      <#{MU_CORE.uuid}> #{session_id.sparql_escape} ."
       query += "   }"
       query += " }"
@@ -39,7 +39,7 @@ module LoginService
     def select_account_by_session(session)
       query =  " SELECT ?group_uuid ?account_uuid ?account FROM <#{settings.graph}> WHERE {"
       query += "   <#{session}> <#{MU_SESSION.account}> ?account ;"
-      query += "                <#{MU_SESSION.group}> ?group ."
+      query += "                <#{MU_EXT.sessionGroup}> ?group ."
       query += "   ?group <#{MU_CORE.uuid}> ?group_uuid ."
       query += "   ?account <#{MU_CORE.uuid}> ?account_uuid ."
       query += "   ?account a <#{RDF::Vocab::FOAF.OnlineAccount}> ."
@@ -51,7 +51,7 @@ module LoginService
       query =  " SELECT ?uri FROM <#{settings.graph}> WHERE {"
       query += "   ?uri <#{MU_SESSION.account}> <#{account}> ;"
       query += "        <#{MU_CORE.uuid}> ?id ; "
-      query += "        <#{MU_SESSION.group}> ?group ."
+      query += "        <#{MU_EXT.sessionGroup}> ?group ."
       query += " }"
       query(query)
     end
@@ -61,12 +61,12 @@ module LoginService
       query += " DELETE {"
       query += "   ?session <#{MU_SESSION.account}> <#{account}> ;"
       query += "            <#{MU_CORE.uuid}> ?id ; "
-      query += "            <#{MU_SESSION.group}> ?group ."
+      query += "            <#{MU_EXT.sessionGroup}> ?group ."
       query += " }"
       query += " WHERE {"
       query += "   ?session <#{MU_SESSION.account}> <#{account}> ;"
       query += "            <#{MU_CORE.uuid}> ?id ; "
-      query += "            <#{MU_SESSION.group}> ?group ."
+      query += "            <#{MU_EXT.sessionGroup}> ?group ."
       query += " }"
       update(query)
     end

--- a/login_service/sparql_queries.rb
+++ b/login_service/sparql_queries.rb
@@ -16,7 +16,8 @@ module LoginService
     def insert_new_session_for_account(account, session_uri, session_id, group_uri, group_id, roles)
       now = DateTime.now
 
-      query =  " INSERT DATA {"
+      query =  " PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>"
+      query += " INSERT DATA {"
       query += "   GRAPH <http://mu.semte.ch/graphs/sessions> {"
       query += "     <#{session_uri}> <#{MU_SESSION.account}> <#{account}> ;"
       query += "                      <#{RDF::Vocab::DC.modified}> #{now.sparql_escape} ;"
@@ -44,7 +45,7 @@ module LoginService
       query += "     ?account a <#{RDF::Vocab::FOAF.OnlineAccount}> ;"
       query += "              <#{MU_CORE.uuid}> ?account_uuid ."
       query += "   }"
-      query += "   FILTER(?g = IRI(CONCAT(\"http://mu.semte.ch/graphs/org/\", ?group_uuid)))"
+      query += "   FILTER(?g = IRI(CONCAT(\"http://mu.semte.ch/graphs/organizations/\", ?group_uuid)))"
       query += " }"
       query(query)
     end
@@ -85,7 +86,7 @@ module LoginService
       query += "             <#{RDF::Vocab::FOAF.account}> ?uri ;"
       query += "             <#{RDF::Vocab::FOAF.member}> ?group ."
       query += "   }"
-      query += "   BIND(IRI(CONCAT(\"http://mu.semte.ch/graphs/org/\", ?group_uuid)) as ?g)"
+      query += "   BIND(IRI(CONCAT(\"http://mu.semte.ch/graphs/organizations/\", ?group_uuid)) as ?g)"
       query += " }"
       query(query)
     end
@@ -115,7 +116,7 @@ module LoginService
       query += "             <#{RDF::Vocab::FOAF.account}> ?uri ;"
       query += "             <#{RDF::Vocab::FOAF.member}> ?group ."
       query += "   }"
-      query += "   BIND(IRI(CONCAT(\"http://mu.semte.ch/graphs/org/\", ?group_uuid)) as ?g)"
+      query += "   BIND(IRI(CONCAT(\"http://mu.semte.ch/graphs/organizations/\", ?group_uuid)) as ?g)"
       query += " }"
       query(query)
     end

--- a/login_service/sparql_queries.rb
+++ b/login_service/sparql_queries.rb
@@ -37,10 +37,11 @@ module LoginService
     end
 
     def select_account_by_session(session)
-      query =  " SELECT ?uuid ?account ?group FROM <#{settings.graph}> WHERE {"
+      query =  " SELECT ?group_uuid ?account_uuid ?account FROM <#{settings.graph}> WHERE {"
       query += "   <#{session}> <#{MU_SESSION.account}> ?account ;"
       query += "                <#{MU_SESSION.group}> ?group ."
-      query += "   ?account <#{MU_CORE.uuid}> ?uuid ."
+      query += "   ?group <#{MU_CORE.uuid}> ?group_uuid ."
+      query += "   ?account <#{MU_CORE.uuid}> ?account_uuid ."
       query += "   ?account a <#{RDF::Vocab::FOAF.OnlineAccount}> ."
       query += " }"
       query(query)

--- a/login_service/sparql_queries.rb
+++ b/login_service/sparql_queries.rb
@@ -42,7 +42,7 @@ module LoginService
       query += "                  <#{MU_EXT.sessionGroup}> ?group ."
       query += "   }"
       query += "   GRAPH <#{graph}> {"
-      query += "     ?group a <#{BESLUIT.Bestuurseenheid}> ;"
+      query += "     ?group a <#{ORG.Organization}> ;"
       query += "            <#{MU_CORE.uuid}> ?group_uuid ."
       query += "   }"
       query += "   GRAPH ?g {"
@@ -78,7 +78,7 @@ module LoginService
     def select_account(id)
       query =  " SELECT ?uri WHERE {"
       query += "   GRAPH <#{graph}> {"
-      query += "     ?group a <#{BESLUIT.Bestuurseenheid}> ;"
+      query += "     ?group a <#{ORG.Organization}> ;"
       query += "            <#{MU_CORE.uuid}> ?group_uuid ."
       query += "   }"
       query += "   GRAPH ?g {"
@@ -96,7 +96,7 @@ module LoginService
     def select_group(group_id)
       query =  " SELECT ?group WHERE {"
       query += "   GRAPH <#{graph}> {"
-      query += "      ?group a <#{BESLUIT.Bestuurseenheid}> ;"
+      query += "      ?group a <#{ORG.Organization}> ;"
       query += "               <#{MU_CORE.uuid}> \"#{group_id}\" ."
       query += "   }"
       query += " }"
@@ -107,7 +107,7 @@ module LoginService
     def select_roles(account_id)
       query =  " SELECT ?role WHERE {"
       query += "   GRAPH <#{graph}> {"
-      query += "     ?group a <#{BESLUIT.Bestuurseenheid}> ;"
+      query += "     ?group a <#{ORG.Organization}> ;"
       query += "            <#{MU_CORE.uuid}> ?group_uuid ."
       query += "   }"
       query += "   GRAPH ?g {"

--- a/login_service/sparql_queries.rb
+++ b/login_service/sparql_queries.rb
@@ -65,15 +65,13 @@ module LoginService
     end
 
     def delete_current_session(account)
-      query = " DELETE WHERE {"
-      query += "   GRAPH <http://mu.semte.ch/graphs/sessions> {"
-      query += "     ?session <#{MU_SESSION.account}> <#{account}> ;"
-      query += "              <#{MU_CORE.uuid}> ?id ; "
-      query += "              <#{RDF::Vocab::DC.modified}> ?modified ; "
-      query += "              <#{MU_EXT.sessionRole}> ?role ;"
-      query += "              <#{MU_EXT.sessionGroup}> ?group ."
-      query += "   }"
-      query += " }"
+      query= %(
+        DELETE WHERE {
+           GRAPH <http://mu.semte.ch/graphs/sessions> {
+             ?session <#{MU_SESSION.account}> <#{account}>;
+               ?p ?o.
+           }
+         })
       update(query)
     end
 

--- a/web.rb
+++ b/web.rb
@@ -95,7 +95,10 @@ post '/sessions/' do
     },
     data: {
       type: 'sessions',
-      id: session_id
+      id: session_id,
+      attributes: {
+        roles: roles
+      }
     },
     relationships: {
       account: {
@@ -140,7 +143,7 @@ delete '/sessions/current/?' do
 
   ###
   # Get account
-  ### 
+  ###
 
   result = select_account_by_session(session_uri)
   error('Invalid session') if result.empty?
@@ -192,7 +195,10 @@ get '/sessions/current/?' do
     },
     data: {
       type: 'sessions',
-      id: session_uri
+      id: session[:session_uuid],
+      attributes: {
+        roles: session[:roles].to_s.split(',')
+      }
     },
     relationships: {
       account: {

--- a/web.rb
+++ b/web.rb
@@ -112,10 +112,10 @@ post '/sessions/' do
       },
       group: {
         links: {
-          related: "/bestuurseenheden/#{data['relationships']['group']['data']['id']}"
+          related: "/groups/#{data['relationships']['group']['data']['id']}"
         },
         data: {
-          type: "bestuurseenheden",
+          type: "groups",
           id: data['relationships']['group']['data']['id']
         }
       }
@@ -212,10 +212,10 @@ get '/sessions/current/?' do
       },
       group: {
         links: {
-          related: "/bestuurseenheden/#{session[:group_uuid]}"
+          related: "/groups/#{session[:group_uuid]}"
         },
         data: {
-          type: "bestuurseenheden",
+          type: "groups",
           id: session[:group_uuid]
         }
       }

--- a/web.rb
+++ b/web.rb
@@ -67,7 +67,8 @@ post '/sessions/' do
   error('account not found.', 400) if result.empty?
   account = result.first
 
-  result = select_group(data["relationships"]["group"]["data"]["id"])
+  group_id = data["relationships"]["group"]["data"]["id"]
+  result = select_group(group_id)
   error('group not found', 400) if result.empty?
   group = result.first
 
@@ -84,8 +85,7 @@ post '/sessions/' do
   # Insert new session
   ###
   session_id = generate_uuid()
-  insert_new_session_for_account(account[:uri].to_s, session_uri, session_id, group[:group].to_s, roles)
-  update_modified(session_uri)
+  insert_new_session_for_account(account[:uri].to_s, session_uri, session_id, group[:group].to_s, group_id, roles)
 
   status 201
   headers['mu-auth-allowed-groups'] = 'CLEAR'
@@ -151,8 +151,6 @@ delete '/sessions/current/?' do
   # Remove session
   ###
 
-  result = select_current_session(account)
-  result.each { |session| update_modified(session[:uri]) }
   delete_current_session(account)
 
   status 204

--- a/web.rb
+++ b/web.rb
@@ -152,7 +152,7 @@ end
 ###
 # GET /sessions/current
 #
-# Returns 204 if current session exists
+# Returns 200 if current session exists
 #         400 if session header is missing or session header is invalid
 ###
 get '/sessions/current/?' do

--- a/web.rb
+++ b/web.rb
@@ -84,6 +84,7 @@ post '/sessions/' do
   update_modified(session_uri)
 
   status 201
+  headers['mu-auth-allowed-groups'] = 'CLEAR'
   {
     links: {
       self: rewrite_url.chomp('/') + '/current'
@@ -151,6 +152,7 @@ delete '/sessions/current/?' do
   delete_current_session(account)
 
   status 204
+  headers['mu-auth-allowed-groups'] = 'CLEAR'
 end
 
 

--- a/web.rb
+++ b/web.rb
@@ -1,5 +1,9 @@
 require_relative 'login_service/sparql_queries.rb'
 
+## Monkeypatch sparql-client with mu-auth-sudo header
+require_relative 'auth_extensions/sudo'
+include AuthExtensions::Sudo
+
 ###
 # Vocabularies
 ###

--- a/web.rb
+++ b/web.rb
@@ -66,6 +66,11 @@ post '/sessions/' do
   result = select_group(data["relationships"]["group"]["data"]["id"])
   error('group not found', 400) if result.empty?
   group = result.first
+
+  result = select_roles(data["relationships"]["account"]["data"]["id"])
+  error('roles not found', 400) if result.empty?
+  roles = result.map { |r| r[:role].to_s }
+
   ###
   # Remove old sessions
   ###
@@ -75,7 +80,7 @@ post '/sessions/' do
   # Insert new session
   ###
   session_id = generate_uuid()
-  insert_new_session_for_account(account[:uri].to_s, session_uri, session_id, group[:group].to_s)
+  insert_new_session_for_account(account[:uri].to_s, session_uri, session_id, group[:group].to_s, roles)
   update_modified(session_uri)
 
   status 201

--- a/web.rb
+++ b/web.rb
@@ -90,20 +90,20 @@ post '/sessions/' do
     relationships: {
       account: {
         links: {
-          related: "/accounts/#{account[:uuid]}"
+          related: "/accounts/#{data['relationships']['account']['data']['id']}"
         },
         data: {
           type: "accounts",
-          id: account[:uuid]
+          id: data['relationships']['account']['data']['id']
         }
       },
       group: {
         links: {
-          related: "/bestuurseenheden/#{group[:uuid]}"
+          related: "/bestuurseenheden/#{data['relationships']['group']['data']['id']}"
         },
         data: {
           type: "bestuurseenheden",
-          id: group[:uuid]
+          id: data['relationships']['group']['data']['id']
         }
       }
     }
@@ -172,14 +172,14 @@ get '/sessions/current/?' do
 
   result = select_account_by_session(session_uri)
   error('Invalid session') if result.empty?
-  account = result.first
+  session = result.first
 
   rewrite_url = rewrite_url_header(request)
 
   status 200
- {
+  {
     links: {
-      self: rewrite_url.chomp('/')
+      self: rewrite_url.chomp('/') + '/current'
     },
     data: {
       type: 'sessions',
@@ -188,11 +188,20 @@ get '/sessions/current/?' do
     relationships: {
       account: {
         links: {
-          related: "/accounts/#{account[:uuid]}"
+          related: "/accounts/#{session[:account_uuid]}"
         },
         data: {
           type: "accounts",
-          id: account[:uuid]
+          id: session[:account_uuid]
+        }
+      },
+      group: {
+        links: {
+          related: "/bestuurseenheden/#{session[:group_uuid]}"
+        },
+        data: {
+          type: "bestuurseenheden",
+          id: session[:group_uuid]
         }
       }
     }

--- a/web.rb
+++ b/web.rb
@@ -11,6 +11,7 @@ include AuthExtensions::Sudo
 MU_ACCOUNT = RDF::Vocabulary.new(MU.to_uri.to_s + 'account/')
 MU_SESSION = RDF::Vocabulary.new(MU.to_uri.to_s + 'session/')
 BESLUIT =  RDF::Vocabulary.new('http://data.vlaanderen.be/ns/besluit#')
+ORG =  RDF::Vocabulary.new('http://www.w3.org/ns/org#')
 
 ###
 # POST /sessions


### PR DESCRIPTION
DGS-231

BREAKING CHANGE (if you dont have org type on bestuurseenheid yet)
--------------
This PR updates the queries to look for org:Organizations instead of besluit:Bestuurseenheid. Notice that org is the parent of a bestuurseenheid. This just broadens the types that can login using mock login to all organizations and their children. 

Main PR:
https://github.com/lblod/app-subsidiepunt/pull/22